### PR TITLE
fix: add www.pepeshows.de to CORS origins

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -141,6 +141,7 @@ if not allowed_patterns:
         "http://localhost:*",  # alle localhost-Ports (Vite 5173/5174 …)
         "http://127.0.0.1:*",
         "https://pepeshows.de",
+        "https://www.pepeshows.de",
         "https://*.vercel.app",  # allow Vercel preview domains via wildcard
     ]
 


### PR DESCRIPTION
## Summary
- Adds `https://www.pepeshows.de` to the CORS fallback origins so requests from the www-subdomain are no longer blocked

## Note
If `CORS_ORIGINS` is set as an environment variable on Render, `https://www.pepeshows.de` must also be added there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)