### PR TITLE
Fix booking requests: migrate to Clerk auth + fix offer field

### DIFF
--- a/backend/routes/request_routes.py
+++ b/backend/routes/request_routes.py
@@ -53,7 +53,7 @@ def _idempotency_store(key: str, payload: dict) -> None:
     _idempotency_cache[key] = (time.time(), payload)
 from datetime import datetime
 from flask import Blueprint, request, jsonify
-from flask_jwt_extended import jwt_required, get_jwt_identity
+from helpers.clerk_auth import clerk_auth_required, get_clerk_user_id
 from services.calculate_price import calculate_price
 from flask import current_app
 from models import db, Artist, BookingRequest
@@ -135,16 +135,21 @@ booking_bp = Blueprint('booking', __name__, url_prefix='/api/requests')
 
 
 @booking_bp.route('/requests', methods=['GET'])
-@jwt_required()
+@clerk_auth_required
 @swag_from('../resources/swagger/requests_get.yml')
 def list_requests():
     """Return booking requests that match the logged-in artist."""
-    user_id = get_jwt_identity()
-    result = request_mgr.get_requests_for_artist_with_recommendation(user_id)
+    clerk_uid = get_clerk_user_id()
+    # Resolve Clerk user ID to internal artist ID
+    artist = Artist.query.filter_by(supabase_user_id=clerk_uid).first()
+    if not artist:
+        current_app.logger.warning(f"list_requests: no artist for clerk_uid={clerk_uid}")
+        return jsonify([])
+    result = request_mgr.get_requests_for_artist_with_recommendation(artist.id)
     return jsonify(result)
 
 @booking_bp.route('/requests/list', methods=['GET'])
-@jwt_required()
+@clerk_auth_required
 def list_requests_admin():
     """Admin list of booking requests.
     
@@ -432,14 +437,14 @@ def create_request():
 
 
 @booking_bp.route('/requests/<int:req_id>/offer', methods=['PUT'])
-@jwt_required()
+@clerk_auth_required
 @swag_from('../resources/swagger/requests_offer_put.yml')
 def set_offer(req_id):
     """Allow a logged-in artist to submit an offer for a request."""
-    # Ermittle internen Artist anhand der Supabase JWT Identity
-    supabase_id = get_jwt_identity()
-    current_app.logger.debug(">>> Supabase ID aus Token: %s", supabase_id)
-    user = Artist.query.filter_by(supabase_user_id=supabase_id).first()
+    # Ermittle internen Artist anhand der Clerk JWT Identity
+    clerk_uid = get_clerk_user_id()
+    current_app.logger.debug(">>> Clerk UID aus Token: %s", clerk_uid)
+    user = Artist.query.filter_by(supabase_user_id=clerk_uid).first()
     if not user:
         return error_response("forbidden", "Artist not found or not allowed", 403)
     user_id = user.id
@@ -450,9 +455,14 @@ def set_offer(req_id):
         return error_response("forbidden", "Not allowed to offer on this request", 403)
 
     data = request.json
-    artist_gage = data.get('artist_gage')
+    # Accept both field names from frontend (price_offered) and legacy (artist_gage)
+    artist_gage = data.get('artist_gage') or data.get('price_offered')
     if artist_gage is None:
-        return error_response("validation_error", "artist_gage is required", 400)
+        return error_response("validation_error", "artist_gage or price_offered is required", 400)
+    try:
+        artist_gage = int(artist_gage)
+    except (TypeError, ValueError):
+        return error_response("validation_error", "artist_gage must be a number", 400)
 
     # Neue Basis berechnen: Preis des aktuellen Artists ersetzen
     base_min = sum(
@@ -506,7 +516,7 @@ def set_offer(req_id):
         return jsonify({'status': req.status}), 200
 
 @booking_bp.route('/requests/<int:req_id>/accept', methods=['PUT'])
-@jwt_required()
+@clerk_auth_required
 def accept_request(req_id: int):
     """Set a booking request status to 'accepted'."""
     try:
@@ -519,7 +529,7 @@ def accept_request(req_id: int):
         return error_response("internal_error", f"accept_request failed: {str(e)}", 500)
 
 @booking_bp.route('/requests/<int:req_id>', methods=['DELETE'])
-@jwt_required()
+@clerk_auth_required
 def delete_request(req_id: int):
     """Delete a booking request by ID."""
     try:

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -156,7 +156,8 @@ function CalendarDayButton({
   className,
   day,
   modifiers,
-  ...props
+  style: _dayPickerStyle,
+  ...rest
 }: React.ComponentProps<typeof DayButton>) {
   const defaultClassNames = getDefaultClassNames()
 
@@ -168,18 +169,20 @@ function CalendarDayButton({
   const isAvailable = (modifiers as any).available;
   const isBlocked = (modifiers as any).blocked;
 
-  // Use inline styles for availability colors to override .btn-secondary background
-  const availabilityStyle: React.CSSProperties = {};
+  // Merge DayPicker's style with our availability colors
+  // DayPicker passes style: undefined which would override our styles if spread after
+  const mergedStyle: React.CSSProperties = { ..._dayPickerStyle };
   if (isAvailable && !modifiers.selected && !modifiers.range_start && !modifiers.range_end) {
-    availabilityStyle.background = 'rgba(22, 163, 74, 0.75)'; // green-600 at 75%
-    availabilityStyle.boxShadow = '0 0 0 2px rgba(74, 222, 128, 0.5)'; // green-400 ring
+    mergedStyle.background = 'rgba(22, 163, 74, 0.75)'; // green-600 at 75%
+    mergedStyle.boxShadow = '0 0 0 2px rgba(74, 222, 128, 0.5)'; // green-400 ring
   } else if (isBlocked && !modifiers.selected && !modifiers.range_start && !modifiers.range_end) {
-    availabilityStyle.background = 'rgba(220, 38, 38, 0.55)'; // red-600 at 55%
-    availabilityStyle.boxShadow = '0 0 0 2px rgba(248, 113, 113, 0.4)'; // red-400 ring
+    mergedStyle.background = 'rgba(220, 38, 38, 0.55)'; // red-600 at 55%
+    mergedStyle.boxShadow = '0 0 0 2px rgba(248, 113, 113, 0.4)'; // red-400 ring
   }
 
   return (
     <button
+      {...rest}
       ref={ref}
       data-day={day.date.toLocaleDateString()}
       data-selected-single={
@@ -192,7 +195,7 @@ function CalendarDayButton({
       data-range-end={modifiers.range_end}
       data-range-middle={modifiers.range_middle}
       aria-pressed={!!modifiers.selected}
-      style={availabilityStyle}
+      style={mergedStyle}
       className={cn(
         "flex aspect-square size-auto w-full min-w-[var(--cell-size)] items-center justify-center text-xs font-black bg-transparent text-white rounded-lg overflow-hidden transition-colors focus-visible:outline-none focus-visible:ring-0 border border-white/10",
         (modifiers.selected && !modifiers.range_middle) && "!bg-white !text-black hover:bg-white/90 focus:bg-white/90 rounded-lg overflow-hidden",
@@ -204,7 +207,6 @@ function CalendarDayButton({
         modifiers.disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
         className
       )}
-      {...props}
     />
   )
 }

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -233,7 +233,7 @@ export default function Admin() {
 
     return {
       total: offers.length,
-      pending: offers.filter((o: any) => !o.status || o.status === 'offen' || o.status === 'pending').length,
+      pending: offers.filter((o: any) => !o.status || o.status === 'offen' || o.status === 'pending' || o.status === 'angefragt' || o.status === 'angeboten').length,
       accepted: offers.filter((o: any) => o.status === 'akzeptiert').length,
       thisMonth: offers.filter((o: any) => {
         const d = getReceivedAt(o);


### PR DESCRIPTION
## Summary
- **Critical bug**: `request_routes.py` still used `@jwt_required()` from flask_jwt_extended which cannot validate Clerk RS256 tokens
- All 5 booking request endpoints returned 401/422 → artists couldn't see or respond to requests
- Fixed artist offer endpoint to accept both `price_offered` (frontend) and `artist_gage` (legacy)
- Fixed admin dashboard pending filter to include `angefragt`/`angeboten` statuses

## Routes fixed
| Endpoint | Was broken | Fix |
|----------|-----------|-----|
| `GET /api/requests/requests` | `@jwt_required()` → 422 | `@clerk_auth_required` + Artist lookup |
| `GET /api/requests/requests/list` | `@jwt_required()` → 422 | `@clerk_auth_required` |
| `PUT .../offer` | `@jwt_required()` + wrong field name | `@clerk_auth_required` + accept both fields |
| `PUT .../accept` | `@jwt_required()` → 422 | `@clerk_auth_required` |
| `DELETE ...` | `@jwt_required()` → 422 | `@clerk_auth_required` |

## Test plan
- [ ] Submit booking via form → request created in DB
- [ ] Admin dashboard shows new request with status "angefragt"
- [ ] Artist sees request in "Meine Anfragen" 
- [ ] Artist can submit offer → status changes to "angeboten"

🤖 Generated with [Claude Code](https://claude.com/claude-code)