### PR TITLE
Redesign profile gage criteria & guidelines page UX

### DIFF
--- a/frontend/src/components/ProfileForm.tsx
+++ b/frontend/src/components/ProfileForm.tsx
@@ -6,7 +6,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
-import { User, MapPin, Music, Euro, FileText, ImageIcon, Images, Upload, X, Award } from "lucide-react";
+import { User, MapPin, Music, Euro, FileText, ImageIcon, Images, Upload, X } from "lucide-react";
 
 interface ProfileFormProps {
   profile: {
@@ -118,11 +118,6 @@ export function ProfileForm({
     const newUrls = profile.galleryUrls.filter((_, i) => i !== index);
     setProfile({ galleryUrls: newUrls });
   };
-
-  const formatMoney = (v?: number | null) =>
-    typeof v === "number" && !Number.isNaN(v)
-      ? new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(v)
-      : '—';
 
   return (
     <form onSubmit={onSubmit} className="space-y-6">
@@ -310,33 +305,33 @@ export function ProfileForm({
 
       {/* Gage Criteria Card - Full Width */}
       <Card>
-        <CardHeader>
+        <CardHeader className="pb-2">
           <div className="flex items-center gap-3">
             <div className="p-2 rounded-lg bg-[#D4A574]/10">
               <Euro className="w-5 h-5 text-[#D4A574]" />
             </div>
             <div>
-              <CardTitle>Gage-Berechnung</CardTitle>
+              <CardTitle>Erfahrung & Qualifikation</CardTitle>
               <CardDescription>
-                Deine Gage wird anhand der folgenden Faktoren berechnet (max. 1.400€)
+                Diese Angaben helfen uns, dein Profil einzuordnen und passende Buchungen zu vermitteln.
               </CardDescription>
             </div>
           </div>
         </CardHeader>
-        <CardContent className="space-y-5">
-          {/* Row 1: Experience + Employment */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <CardContent className="pt-6">
+          {/* Top row: 3 columns on desktop */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {/* Stage Experience */}
             <div className="space-y-2">
               <Label htmlFor="stageExperience">
                 Bühnenerfahrung <span className="text-[#D4A574]">*</span>
-                <span className="text-xs text-white/50 ml-2">(30%)</span>
               </Label>
               <select
                 id="stageExperience"
                 value={profile.stageExperience}
                 onChange={(e) => setProfile({ stageExperience: e.target.value })}
                 disabled={locked}
-                className="w-full rounded-md border border-white/20 bg-transparent px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-[#D4A574]/50 disabled:opacity-50"
+                className="w-full rounded-xl border border-white/20 bg-transparent px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-[#D4A574]/50 disabled:opacity-50 transition-colors hover:border-white/30"
               >
                 {stageExperienceOptions.map(o => (
                   <option key={o.value} value={o.value} className="bg-[#1A1A1A]">{o.label}</option>
@@ -347,17 +342,17 @@ export function ProfileForm({
               )}
             </div>
 
+            {/* Employment Type */}
             <div className="space-y-2">
               <Label htmlFor="employmentType">
                 Beschäftigungsart <span className="text-[#D4A574]">*</span>
-                <span className="text-xs text-white/50 ml-2">(25%)</span>
               </Label>
               <select
                 id="employmentType"
                 value={profile.employmentType}
                 onChange={(e) => setProfile({ employmentType: e.target.value })}
                 disabled={locked}
-                className="w-full rounded-md border border-white/20 bg-transparent px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-[#D4A574]/50 disabled:opacity-50"
+                className="w-full rounded-xl border border-white/20 bg-transparent px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-[#D4A574]/50 disabled:opacity-50 transition-colors hover:border-white/30"
               >
                 {employmentTypeOptions.map(o => (
                   <option key={o.value} value={o.value} className="bg-[#1A1A1A]">{o.label}</option>
@@ -367,58 +362,18 @@ export function ProfileForm({
                 <p className="text-red-400 text-sm">{fieldErrors.employmentType}</p>
               )}
             </div>
-          </div>
 
-          {/* Row 2: Education + Awards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label>
-                Zirkusausbildung
-                <span className="text-xs text-white/50 ml-2">(15%)</span>
-              </Label>
-              <label
-                className={cn(
-                  "flex items-center gap-3 p-3 rounded-xl cursor-pointer transition-all duration-200",
-                  profile.circusEducation
-                    ? "bg-[#D4A574]/20 border-2 border-[#D4A574]"
-                    : "bg-white/5 border border-white/10 hover:border-[#D4A574]/50",
-                  locked && "opacity-50 cursor-not-allowed"
-                )}
-              >
-                <input
-                  type="checkbox"
-                  checked={profile.circusEducation}
-                  onChange={(e) => !locked && setProfile({ circusEducation: e.target.checked })}
-                  disabled={locked}
-                  className="sr-only"
-                />
-                <div className={cn(
-                  "w-5 h-5 rounded border-2 flex items-center justify-center transition-colors",
-                  profile.circusEducation
-                    ? "bg-[#D4A574] border-[#D4A574]"
-                    : "border-white/30"
-                )}>
-                  {profile.circusEducation && (
-                    <svg className="w-3 h-3 text-black" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                    </svg>
-                  )}
-                </div>
-                <span className="text-sm text-white">Ausbildung an staatl. Zirkusschule</span>
-              </label>
-            </div>
-
+            {/* Awards */}
             <div className="space-y-2">
               <Label htmlFor="awardsLevel">
                 Auszeichnungen / International
-                <span className="text-xs text-white/50 ml-2">(15%)</span>
               </Label>
               <select
                 id="awardsLevel"
                 value={profile.awardsLevel}
                 onChange={(e) => setProfile({ awardsLevel: e.target.value })}
                 disabled={locked}
-                className="w-full rounded-md border border-white/20 bg-transparent px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-[#D4A574]/50 disabled:opacity-50"
+                className="w-full rounded-xl border border-white/20 bg-transparent px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-[#D4A574]/50 disabled:opacity-50 transition-colors hover:border-white/30"
               >
                 {awardsOptions.map(o => (
                   <option key={o.value} value={o.value} className="bg-[#1A1A1A]">{o.label}</option>
@@ -427,19 +382,22 @@ export function ProfileForm({
             </div>
           </div>
 
-          {/* Row 3: Pepe Years + Exclusivity */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {/* Divider */}
+          <div className="my-6 border-t border-white/5" />
+
+          {/* Bottom row: Pepe Years dropdown + two toggle cards side by side */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-5">
+            {/* Pepe Years */}
             <div className="space-y-2">
               <Label htmlFor="pepeYears">
                 Jahre bei Pepe
-                <span className="text-xs text-white/50 ml-2">(10%)</span>
               </Label>
               <select
                 id="pepeYears"
                 value={profile.pepeYears}
                 onChange={(e) => setProfile({ pepeYears: parseInt(e.target.value) || 0 })}
                 disabled={locked}
-                className="w-full rounded-md border border-white/20 bg-transparent px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-[#D4A574]/50 disabled:opacity-50"
+                className="w-full rounded-xl border border-white/20 bg-transparent px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-[#D4A574]/50 disabled:opacity-50 transition-colors hover:border-white/30"
               >
                 {pepeYearsOptions.map(o => (
                   <option key={o.value} value={o.value} className="bg-[#1A1A1A]">{o.label}</option>
@@ -447,59 +405,70 @@ export function ProfileForm({
               </select>
             </div>
 
-            <div className="space-y-2">
-              <Label>
-                Exklusiv für Pepe
-                <span className="text-xs text-white/50 ml-2">(5%)</span>
-              </Label>
-              <label
-                className={cn(
-                  "flex items-center gap-3 p-3 rounded-xl cursor-pointer transition-all duration-200",
-                  profile.pepeExclusivity
-                    ? "bg-[#D4A574]/20 border-2 border-[#D4A574]"
-                    : "bg-white/5 border border-white/10 hover:border-[#D4A574]/50",
-                  locked && "opacity-50 cursor-not-allowed"
+            {/* Circus Education Toggle */}
+            <label
+              className={cn(
+                "flex items-center gap-3 px-4 py-3 rounded-xl cursor-pointer transition-all duration-200 self-end",
+                profile.circusEducation
+                  ? "bg-[#D4A574]/15 border-2 border-[#D4A574]/60"
+                  : "bg-white/[0.03] border border-white/10 hover:border-[#D4A574]/30 hover:bg-white/[0.05]",
+                locked && "opacity-50 cursor-not-allowed"
+              )}
+            >
+              <input
+                type="checkbox"
+                checked={profile.circusEducation}
+                onChange={(e) => !locked && setProfile({ circusEducation: e.target.checked })}
+                disabled={locked}
+                className="sr-only"
+              />
+              <div className={cn(
+                "w-5 h-5 rounded border-2 flex-shrink-0 flex items-center justify-center transition-colors",
+                profile.circusEducation
+                  ? "bg-[#D4A574] border-[#D4A574]"
+                  : "border-white/30"
+              )}>
+                {profile.circusEducation && (
+                  <svg className="w-3 h-3 text-black" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
                 )}
-              >
-                <input
-                  type="checkbox"
-                  checked={profile.pepeExclusivity}
-                  onChange={(e) => !locked && setProfile({ pepeExclusivity: e.target.checked })}
-                  disabled={locked}
-                  className="sr-only"
-                />
-                <div className={cn(
-                  "w-5 h-5 rounded border-2 flex items-center justify-center transition-colors",
-                  profile.pepeExclusivity
-                    ? "bg-[#D4A574] border-[#D4A574]"
-                    : "border-white/30"
-                )}>
-                  {profile.pepeExclusivity && (
-                    <svg className="w-3 h-3 text-black" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                    </svg>
-                  )}
-                </div>
-                <span className="text-sm text-white">Ich arbeite exklusiv für Pepe Shows</span>
-              </label>
-            </div>
-          </div>
+              </div>
+              <span className="text-sm text-white">Zirkusausbildung</span>
+            </label>
 
-          {/* Calculated Gage Display */}
-          {(profile.calculatedGage || profile.priceMin || profile.priceMax) && (
-            <div className="mt-4 rounded-xl border border-[#D4A574]/30 bg-[#D4A574]/5 p-4">
-              <div className="flex items-center gap-2 mb-2">
-                <Award className="w-4 h-4 text-[#D4A574]" />
-                <span className="text-sm font-medium text-[#D4A574]">Deine berechnete Gage</span>
+            {/* Exclusivity Toggle */}
+            <label
+              className={cn(
+                "flex items-center gap-3 px-4 py-3 rounded-xl cursor-pointer transition-all duration-200 self-end",
+                profile.pepeExclusivity
+                  ? "bg-[#D4A574]/15 border-2 border-[#D4A574]/60"
+                  : "bg-white/[0.03] border border-white/10 hover:border-[#D4A574]/30 hover:bg-white/[0.05]",
+                locked && "opacity-50 cursor-not-allowed"
+              )}
+            >
+              <input
+                type="checkbox"
+                checked={profile.pepeExclusivity}
+                onChange={(e) => !locked && setProfile({ pepeExclusivity: e.target.checked })}
+                disabled={locked}
+                className="sr-only"
+              />
+              <div className={cn(
+                "w-5 h-5 rounded border-2 flex-shrink-0 flex items-center justify-center transition-colors",
+                profile.pepeExclusivity
+                  ? "bg-[#D4A574] border-[#D4A574]"
+                  : "border-white/30"
+              )}>
+                {profile.pepeExclusivity && (
+                  <svg className="w-3 h-3 text-black" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                )}
               </div>
-              <div className="text-2xl font-bold text-white">
-                {formatMoney(profile.priceMin)} – {formatMoney(profile.priceMax)}
-              </div>
-              <p className="text-xs text-white/50 mt-1">
-                Basierend auf deinen Angaben. Die endgültige Gage wird pro Event individuell berechnet.
-              </p>
-            </div>
-          )}
+              <span className="text-sm text-white">Exklusiv bei Pepe</span>
+            </label>
+          </div>
         </CardContent>
       </Card>
 

--- a/frontend/src/pages/ArtistGuidlines.tsx
+++ b/frontend/src/pages/ArtistGuidlines.tsx
@@ -1,8 +1,114 @@
 import * as React from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
+import {
+  BookOpen,
+  CheckCircle2,
+  Clock,
+  Shield,
+  CreditCard,
+  Camera,
+  MessageSquare,
+  HelpCircle,
+  AlertCircle,
+  ChevronRight,
+} from "lucide-react";
 
 const API_BASE = (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_URL) || '';
+
+interface GuideSection {
+  id: string;
+  icon: React.ElementType;
+  title: string;
+  items: string[];
+}
+
+const sections: GuideSection[] = [
+  {
+    id: "flow",
+    icon: BookOpen,
+    title: "So funktioniert's",
+    items: [
+      "Veranstalter geben Datum, Ort & Budget an",
+      "Wir schlagen passende Artists vor",
+      "Du nennst Konditionen, bei Zusage koordinieren wir alles",
+      "Performance, Feedback & Zahlung mit Support",
+    ],
+  },
+  {
+    id: "rights",
+    icon: CheckCircle2,
+    title: "Deine Rechte",
+    items: [
+      "Alle relevanten Infos vor deiner Zusage",
+      "Du entscheidest frei, welche Anfragen du annimmst",
+      "Du definierst deine Konditionen selbst",
+      "Profil, Medien und Links jederzeit bearbeitbar",
+    ],
+  },
+  {
+    id: "standards",
+    icon: Shield,
+    title: "Unsere Standards",
+    items: [
+      "Bestätigte Termine sind verbindlich",
+      "Antwort auf Anfragen innerhalb von 24–48 h",
+      "Pünktlichkeit & klare Kommunikation",
+      "Keine riskanten Acts ohne Freigabe",
+    ],
+  },
+  {
+    id: "fees",
+    icon: CreditCard,
+    title: "Honorar & Gebühren",
+    items: [
+      "Netto-Gage + ggf. Reisekosten transparent ausgewiesen",
+      "Service-Fee wird separat aufgeführt",
+      "Zahlung nach Auftritt per Rechnung",
+    ],
+  },
+  {
+    id: "cancellations",
+    icon: AlertCircle,
+    title: "Storno & Ausfälle",
+    items: [
+      "Kundenseitig: Staffelung je nach Abstand zum Termin",
+      "Artistenseitig: Nur aus wichtigem Grund",
+      "Höhere Gewalt: Fairer Ausgleich nach Vertrag",
+    ],
+  },
+  {
+    id: "media",
+    icon: Camera,
+    title: "Medien & Rechte",
+    items: [
+      "Deine Bilder & Videos bleiben dein Eigentum",
+      "Nutzung durch PepeShows nur zur Bewerbung",
+      "Credits werden immer genannt",
+      "Freigaben jederzeit widerrufbar",
+    ],
+  },
+  {
+    id: "communication",
+    icon: MessageSquare,
+    title: "Kommunikation",
+    items: [
+      "Bevorzugt über die Plattform",
+      "Ziel: Antwort innerhalb von 24–48 h",
+      "Bei Abwesenheit: Auto-Reply im Profil",
+    ],
+  },
+  {
+    id: "help",
+    icon: HelpCircle,
+    title: "Hilfe & Kontakt",
+    items: [
+      "Technik / Profil: info@pepeshows.de",
+      "Buchungen / Verträge: info@pepeshows.de",
+      "Notfälle am Eventtag: Hotline bei bestätigten Buchungen",
+    ],
+  },
+];
 
 export default function ArtistGuidlines() {
   const { token, refreshUser } = useAuth();
@@ -29,7 +135,6 @@ export default function ArtistGuidlines() {
         const t = await res.text();
         throw new Error(t || `HTTP ${res.status}`);
       }
-      // Refresh user data so guidelines_accepted=true is reflected in context
       await refreshUser();
       try { window.dispatchEvent(new Event('artist:guidelines-accepted')); } catch {}
       navigate('/profile');
@@ -42,189 +147,119 @@ export default function ArtistGuidlines() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <header className="border-b border-white/10 bg-gradient-to-b from-white/5 to-transparent">
-        <div className="mx-auto max-w-5xl px-4 py-6 flex items-center justify-between">
-          <h1 className="text-2xl md:text-3xl font-bold">Artist Guidelines</h1>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={accept}
-              disabled={!checked || submitting}
-              className="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-medium text-black transition hover:bg-white/90 disabled:opacity-60 disabled:cursor-not-allowed"
-              title={!checked ? 'Bitte Checkbox bestätigen' : 'Richtlinien akzeptieren'}
-            >
-              {submitting ? 'Speichere…' : 'Akzeptieren'}
-            </button>
+      {/* Header */}
+      <header className="sticky top-0 z-20 border-b border-white/10 bg-black/80 backdrop-blur-xl">
+        <div className="mx-auto max-w-5xl px-4 sm:px-6 py-4 flex items-center justify-between">
+          <div>
+            <h1 className="text-xl md:text-2xl font-bold">Richtlinien</h1>
+            <p className="text-sm text-gray-400 hidden sm:block">Bitte lies und akzeptiere unsere Richtlinien</p>
+          </div>
+          <div className="flex items-center gap-3">
             <Link
               to="/home"
-              className="text-sm text-gray-300 hover:text-white underline underline-offset-4"
+              className="text-sm text-gray-400 hover:text-white transition-colors"
             >
-              Zur Startseite
+              Startseite
             </Link>
           </div>
         </div>
       </header>
 
-      <main className="mx-auto max-w-5xl px-4 py-8 md:py-12">
-        {/* Consent Bar */}
-        <div className="mb-6 flex items-start gap-3 rounded-lg border border-white/10 bg-white/[0.03] p-4">
-          <input
-            id="consent"
-            type="checkbox"
-            checked={checked}
-            onChange={(e) => setChecked(e.target.checked)}
-            className="mt-1 h-4 w-4 rounded border-white/20 bg-transparent text-white focus:ring-white"
-          />
-          <label htmlFor="consent" className="text-sm text-gray-300">
-            Ich habe die Richtlinien gelesen und akzeptiere sie.
-          </label>
+      <main className="mx-auto max-w-5xl px-4 sm:px-6 py-8 md:py-12">
+        {/* TL;DR Hero Card */}
+        <div className="mb-10 rounded-2xl bg-gradient-to-br from-[#D4A574]/10 to-[#D4A574]/5 border border-[#D4A574]/20 p-6 md:p-8">
+          <h2 className="text-lg md:text-xl font-semibold text-[#D4A574] mb-3">Kurz gesagt</h2>
+          <p className="text-gray-300 leading-relaxed max-w-3xl">
+            Fair, sicher, transparent. Du entscheidest über Anfragen & Gagen –
+            wir kümmern uns um Matching, Vertrag & Support. Medien bleiben deine,
+            wir nutzen sie nur zur Bewerbung. Bitte antworte auf Anfragen innerhalb
+            von <strong className="text-white">24–48 Stunden</strong> und halte
+            Sicherheits-/Venue-Regeln ein.
+          </p>
         </div>
+
+        {/* Sections Grid */}
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3 mb-10">
+          {sections.map((section) => {
+            const Icon = section.icon;
+            return (
+              <div
+                key={section.id}
+                className="group bg-white/[0.03] backdrop-blur-sm border border-white/10 rounded-2xl p-5 md:p-6 hover:bg-white/[0.06] transition-all duration-200"
+              >
+                <div className="flex items-center gap-3 mb-4">
+                  <div className="p-2.5 rounded-xl bg-[#D4A574]/10 group-hover:bg-[#D4A574]/15 transition-colors">
+                    <Icon className="w-5 h-5 text-[#D4A574]" />
+                  </div>
+                  <h3 className="font-semibold text-white">{section.title}</h3>
+                </div>
+                <ul className="space-y-2">
+                  {section.items.map((item, i) => (
+                    <li key={i} className="flex items-start gap-2 text-sm text-gray-400 leading-relaxed">
+                      <ChevronRight className="w-3.5 h-3.5 text-[#D4A574]/60 mt-0.5 flex-shrink-0" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Error */}
         {error && (
-          <div className="mb-6 rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200">
+          <div className="mb-6 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
             {error}
           </div>
         )}
 
-        {/* Intro */}
-        <section className="mb-8 md:mb-10">
-          <p className="text-gray-300 text-lg leading-relaxed">
-            Willkommen bei PepeShows! Diese Seite erklärt dir transparent,{" "}
-            wie unsere Plattform funktioniert, welche Rechte du hast und welche Standards
-            wir für alle Buchungen setzen. Klar, fair, auf den Punkt.
-          </p>
-        </section>
-
-        {/* Inhaltsverzeichnis */}
-        <nav className="mb-10 rounded-lg border border-white/10 bg-white/[0.03] p-4">
-          <h2 className="font-semibold mb-2">Inhalt</h2>
-          <ul className="grid sm:grid-cols-2 gap-y-1 text-sm text-gray-300">
-            <li><a className="hover:underline" href="#flow">So funktioniert's</a></li>
-            <li><a className="hover:underline" href="#rights">Deine Rechte</a></li>
-            <li><a className="hover:underline" href="#standards">Unsere Standards</a></li>
-            <li><a className="hover:underline" href="#fees">Honorar & Gebühren</a></li>
-            <li><a className="hover:underline" href="#cancellations">Storno & Ausfälle</a></li>
-            <li><a className="hover:underline" href="#media">Medien & Nutzungsrechte</a></li>
-            <li><a className="hover:underline" href="#privacy">Datenschutz</a></li>
-            <li><a className="hover:underline" href="#communication">Kommunikation</a></li>
-            <li><a className="hover:underline" href="#help">Hilfe & Kontakt</a></li>
-          </ul>
-        </nav>
-
-        {/* TL;DR Karte */}
-        <section className="mb-10 rounded-lg border border-white/10 bg-white/[0.04] p-5">
-          <h2 className="text-xl font-semibold mb-2">Kurz gesagt (TL;DR)</h2>
-          <p className="text-gray-300">
-            Fair, sicher, transparent. Du entscheidest über Anfragen &amp; Gagen,
-            wir kümmern uns um Matching, Vertrag &amp; Support. Medien bleiben deine –
-            wir nutzen sie nur zur Bewerbung. Bitte antworte auf Anfragen innerhalb von{" "}
-            <strong>24–48 h</strong> und halte Sicherheits‑/Venue‑Regeln ein.
-          </p>
-        </section>
-
-        {/* Abschnitte */}
-        <section id="flow" className="mb-10">
-          <h3 className="text-lg font-semibold mb-2">So funktioniert's (4 Schritte)</h3>
-          <ol className="list-decimal list-inside space-y-1 text-gray-300">
-            <li><strong>Anfrage:</strong> Veranstalter geben Datum, Ort, Rahmen & Budget an.</li>
-            <li><strong>Matching:</strong> Wir schlagen passende Artists vor (Disziplin, Stil, Verfügbarkeit).</li>
-            <li><strong>Angebot & Zusage:</strong> Du nennst Konditionen; bei Zusage koordinieren wir Ablauf & Details.</li>
-            <li><strong>Auftritt & Abrechnung:</strong> Performance, Feedback, Zahlung – mit Support bis zum Schluss.</li>
-          </ol>
-        </section>
-
-        <section id="rights" className="mb-10">
-          <h3 className="text-lg font-semibold mb-2">Deine Rechte</h3>
-          <ul className="list-disc list-inside space-y-1 text-gray-300">
-            <li><strong>Transparenz:</strong> Alle relevanten Infos vor deiner Zusage.</li>
-            <li><strong>Selbstbestimmung:</strong> Du entscheidest frei, welche Anfragen du annimmst.</li>
-            <li><strong>Eigene Gagen:</strong> Du definierst Konditionen; wir unterstützen bei der Kalkulation.</li>
-            <li><strong>Datenkontrolle:</strong> Profil, Medien und Links jederzeit bearbeiten/löschen.</li>
-            <li><strong>Support:</strong> Schnelle Hilfe bei Technik, Rechten oder Konflikten.</li>
-          </ul>
-        </section>
-
-        <section id="standards" className="mb-10">
-          <h3 className="text-lg font-semibold mb-2">Unsere Standards (für alle Buchungen)</h3>
-          <ul className="list-disc list-inside space-y-1 text-gray-300">
-            <li><strong>Zuverlässigkeit:</strong> Bestätigte Termine sind verbindlich.</li>
-            <li><strong>Response-Zeit:</strong> Antwort auf Anfragen innerhalb von <strong>24–48 h</strong>.</li>
-            <li><strong>Professionalität:</strong> Pünktlichkeit, klare Kommunikation, Technik-/Sicherheits‑Rider beachten.</li>
-            <li><strong>Sicherheit:</strong> Keine riskanten Acts ohne Freigabe/Absicherung; Venue-Regeln einhalten.</li>
-            <li><strong>Fair Play:</strong> Keine Umgehung vereinbarter Prozesse/Verträge.</li>
-            <li><strong>Respekt & Inklusion:</strong> Null Toleranz für Diskriminierung & grenzüberschreitendes Verhalten.</li>
-          </ul>
-        </section>
-
-        <section id="fees" className="mb-10">
-          <h3 className="text-lg font-semibold mb-2">Honorar & Gebühren</h3>
-          <ul className="list-disc list-inside space-y-1 text-gray-300">
-            <li><strong>Dein Honorar:</strong> Netto‑Gage + ggf. Reisekosten/Spesen – transparent im Angebot.</li>
-            <li><strong>Service‑Fee:</strong> Plattform-/Vermittlungsgebühr wird separat ausgewiesen.</li>
-            <li><strong>Zahlung:</strong> Üblicherweise nach Auftritt per Rechnung; Anzahlung/Vorkasse möglich.</li>
-          </ul>
-        </section>
-
-        <section id="cancellations" className="mb-10">
-          <h3 className="text-lg font-semibold mb-2">Storno & Ausfälle (Kurzregel)</h3>
-          <ul className="list-disc list-inside space-y-1 text-gray-300">
-            <li><strong>Kundenseitig:</strong> Staffelung je nach Abstand zum Termin (z. B. 30/50/100 %).</li>
-            <li><strong>Artistenseitig:</strong> Nur aus wichtigem Grund; wir helfen beim gleichwertigen Ersatz.</li>
-            <li><strong>Höhere Gewalt:</strong> Fairer Ausgleich nach Vertrag & Aufwand.</li>
-          </ul>
-        </section>
-
-        <section id="media" className="mb-10">
-          <h3 className="text-lg font-semibold mb-2">Medien & Nutzungsrechte</h3>
-          <ul className="list-disc list-inside space-y-1 text-gray-300">
-            <li><strong>Eigentum:</strong> Deine Bilder/Videos bleiben dein Eigentum.</li>
-            <li><strong>Nutzung durch PepeShows:</strong> Nur zur Bewerbung deiner Person/Acts & der Plattform – keine Weitergabe/Verkäufe.</li>
-            <li><strong>Credits:</strong> Wir nennen dich (und Fotocredits, wenn hinterlegt).</li>
-            <li><strong>Widerruf:</strong> Du kannst Freigaben für Medien jederzeit widerrufen.</li>
-          </ul>
-        </section>
-
-        <section id="privacy" className="mb-10">
-          <h3 className="text-lg font-semibold mb-2">Datenschutz</h3>
-          <ul className="list-disc list-inside space-y-1 text-gray-300">
-            <li>Wir verarbeiten nur, was für Matching, Buchung und Abrechnung nötig ist.</li>
-            <li>Du kannst alle personenbezogenen Daten exportieren oder löschen (Profil &gt; Datenschutz).</li>
-            <li>Mehr Details in unserer Datenschutzerklärung.</li>
-          </ul>
-        </section>
-
-        <section id="communication" className="mb-10">
-          <h3 className="text-lg font-semibold mb-2">Kommunikation & Erreichbarkeit</h3>
-          <ul className="list-disc list-inside space-y-1 text-gray-300">
-            <li><strong>Ein Kanal:</strong> Bevorzugt über die Plattform (Chat/E‑Mail), damit nichts verloren geht.</li>
-            <li><strong>Response‑Ziel:</strong> 24–48 h. Wenn du verhindert bist → kurzer Auto‑Reply im Profil.</li>
-          </ul>
-        </section>
-
-        <section id="help" className="mb-12">
-          <h3 className="text-lg font-semibold mb-2">Hilfe & Kontakt</h3>
-          <ul className="list-disc list-inside space-y-1 text-gray-300">
-            <li><strong>Technik/Profil:</strong> info@pepeshows.de</li>
-            <li><strong>Buchungen/Verträge:</strong> info@pepeshows.de</li>
-            <li><strong>Notfälle am Eventtag:</strong> Hotline (erscheint bei bestätigten Buchungen)</li>
-          </ul>
-        </section>
-
-        <div className="mt-8 flex items-center justify-between border-t border-white/10 pt-6">
-          <span className="text-xs text-gray-400">Stand: {new Date().toLocaleDateString("de-DE")}</span>
-          <div className="flex items-center gap-3">
+        {/* Consent & Accept - Sticky Footer Card */}
+        <div className="sticky bottom-4 rounded-2xl border border-white/10 bg-black/90 backdrop-blur-xl p-5 md:p-6 shadow-2xl shadow-black/50">
+          <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+            <label
+              htmlFor="consent"
+              className="flex items-start gap-3 cursor-pointer flex-1 select-none"
+            >
+              <div className="mt-0.5">
+                <input
+                  id="consent"
+                  type="checkbox"
+                  checked={checked}
+                  onChange={(e) => setChecked(e.target.checked)}
+                  className="sr-only"
+                />
+                <div className={`w-5 h-5 rounded border-2 flex items-center justify-center transition-all duration-200 ${
+                  checked
+                    ? "bg-[#D4A574] border-[#D4A574]"
+                    : "border-white/30 hover:border-[#D4A574]/50"
+                }`}>
+                  {checked && (
+                    <svg className="w-3 h-3 text-black" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                    </svg>
+                  )}
+                </div>
+              </div>
+              <span className="text-sm text-gray-300 leading-relaxed">
+                Ich habe die Richtlinien gelesen und akzeptiere sie.
+              </span>
+            </label>
             <button
               onClick={accept}
               disabled={!checked || submitting}
-              className="inline-flex items-center rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition hover:bg-white/90 disabled:opacity-60 disabled:cursor-not-allowed"
+              className="inline-flex items-center justify-center whitespace-nowrap rounded-xl bg-[#D4A574] px-6 py-3 text-sm font-semibold text-black transition-all duration-200 hover:bg-[#E6B887] disabled:opacity-40 disabled:cursor-not-allowed shadow-lg shadow-[#D4A574]/20 disabled:shadow-none"
             >
               {submitting ? 'Speichere…' : 'Richtlinien akzeptieren'}
             </button>
-            <Link
-              to="/home"
-              className="text-sm text-gray-300 hover:text-white underline underline-offset-4"
-            >
-              Zur Startseite
-            </Link>
           </div>
+        </div>
+
+        {/* Footer */}
+        <div className="mt-8 text-center">
+          <p className="text-xs text-gray-500">
+            Stand: {new Date().toLocaleDateString("de-DE")} · Bei Fragen:{' '}
+            <a href="mailto:info@pepeshows.de" className="text-[#D4A574] hover:underline">info@pepeshows.de</a>
+          </p>
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- Remove "Deine berechnete Gage" display box and all percentage labels from profile form
- Reorganize gage criteria into clean 3-column grid (dropdowns top, toggles bottom row)
- Redesign guidelines acceptance page with card grid layout matching dashboard Richtlinien
- Sticky consent bar with branded accept button at bottom of page
- Consistent padding, border-radius, and hover states

## Test plan
- [ ] Profile page shows gage criteria without percentages or calculated gage box
- [ ] Fields align nicely on desktop (3 columns) and stack on mobile
- [ ] Guidelines page renders card grid with sections
- [ ] Accept checkbox + button work correctly at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)