### PR TITLE
Image compression (max 0.5MB) and square crop for profile pictures

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -49,6 +49,7 @@
         "react-day-picker": "^9.10.0",
         "react-dom": "^19.1.1",
         "react-i18next": "^15.7.3",
+        "react-image-crop": "^11.0.10",
         "react-router-dom": "^7.8.2",
         "tailwind-merge": "^3.3.1"
       },
@@ -6623,6 +6624,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-image-crop": {
+      "version": "11.0.10",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-11.0.10.tgz",
+      "integrity": "sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "react-day-picker": "^9.10.0",
     "react-dom": "^19.1.1",
     "react-i18next": "^15.7.3",
+    "react-image-crop": "^11.0.10",
     "react-router-dom": "^7.8.2",
     "tailwind-merge": "^3.3.1"
   },

--- a/frontend/src/components/ImageCropModal.tsx
+++ b/frontend/src/components/ImageCropModal.tsx
@@ -1,0 +1,199 @@
+import React, { useState, useRef, useCallback, useEffect } from "react";
+import ReactCrop, { type Crop, centerCrop, makeAspectCrop } from "react-image-crop";
+import "react-image-crop/dist/ReactCrop.css";
+import { Button } from "@/components/ui/button";
+import { Crop as CropIcon, X, RotateCw, ZoomIn } from "lucide-react";
+
+interface ImageCropModalProps {
+  file: File;
+  onCropped: (croppedFile: File) => void;
+  onCancel: () => void;
+  onNewImage: () => void;
+}
+
+function centerAspectCrop(
+  mediaWidth: number,
+  mediaHeight: number,
+  aspect: number
+): Crop {
+  return centerCrop(
+    makeAspectCrop(
+      {
+        unit: "%",
+        width: 90,
+      },
+      aspect,
+      mediaWidth,
+      mediaHeight
+    ),
+    mediaWidth,
+    mediaHeight
+  );
+}
+
+export function ImageCropModal({ file, onCropped, onCancel, onNewImage }: ImageCropModalProps) {
+  const [crop, setCrop] = useState<Crop>();
+  const [imgSrc, setImgSrc] = useState("");
+  const imgRef = useRef<HTMLImageElement>(null);
+  const [processing, setProcessing] = useState(false);
+
+  useEffect(() => {
+    const url = URL.createObjectURL(file);
+    setImgSrc(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  const onImageLoad = useCallback((e: React.SyntheticEvent<HTMLImageElement>) => {
+    const { naturalWidth, naturalHeight } = e.currentTarget;
+    const crop = centerAspectCrop(naturalWidth, naturalHeight, 1);
+    setCrop(crop);
+  }, []);
+
+  const handleCrop = useCallback(async () => {
+    if (!imgRef.current || !crop) return;
+    setProcessing(true);
+
+    try {
+      const image = imgRef.current;
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+
+      const scaleX = image.naturalWidth / image.width;
+      const scaleY = image.naturalHeight / image.height;
+
+      const pixelCrop = {
+        x: (crop.x / 100) * image.naturalWidth,
+        y: (crop.y / 100) * image.naturalHeight,
+        width: (crop.width / 100) * image.naturalWidth,
+        height: (crop.height / 100) * image.naturalHeight,
+      };
+
+      // Use percentage-based crop if unit is %, otherwise use pixel values
+      const cropX = crop.unit === "%" ? pixelCrop.x : crop.x * scaleX;
+      const cropY = crop.unit === "%" ? pixelCrop.y : crop.y * scaleY;
+      const cropW = crop.unit === "%" ? pixelCrop.width : crop.width * scaleX;
+      const cropH = crop.unit === "%" ? pixelCrop.height : crop.height * scaleY;
+
+      // Output at max 800x800
+      const outputSize = Math.min(cropW, 800);
+      canvas.width = outputSize;
+      canvas.height = outputSize;
+
+      ctx.drawImage(
+        image,
+        cropX,
+        cropY,
+        cropW,
+        cropH,
+        0,
+        0,
+        outputSize,
+        outputSize
+      );
+
+      canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            const croppedFile = new File([blob], file.name.replace(/\.[^.]+$/, ".webp"), {
+              type: "image/webp",
+            });
+            onCropped(croppedFile);
+          }
+          setProcessing(false);
+        },
+        "image/webp",
+        0.9
+      );
+    } catch {
+      setProcessing(false);
+    }
+  }, [crop, file, onCropped]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm p-4">
+      <div className="bg-[#1A1A1A] border border-white/10 rounded-2xl max-w-lg w-full max-h-[90vh] overflow-hidden shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between p-5 border-b border-white/10">
+          <div>
+            <h3 className="text-lg font-semibold text-white flex items-center gap-2">
+              <CropIcon className="w-5 h-5 text-[#D4A574]" />
+              Bild zuschneiden
+            </h3>
+            <p className="text-sm text-gray-400 mt-0.5">
+              Wähle den quadratischen Ausschnitt für dein Profilbild
+            </p>
+          </div>
+          <button
+            onClick={onCancel}
+            className="p-2 rounded-lg hover:bg-white/10 transition-colors text-gray-400 hover:text-white"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Crop Area */}
+        <div className="p-5 flex justify-center bg-black/30">
+          {imgSrc && (
+            <ReactCrop
+              crop={crop}
+              onChange={(_, percentCrop) => setCrop(percentCrop)}
+              aspect={1}
+              circularCrop={false}
+              className="max-h-[50vh]"
+            >
+              <img
+                ref={imgRef}
+                src={imgSrc}
+                alt="Zuschneiden"
+                onLoad={onImageLoad}
+                className="max-h-[50vh] object-contain"
+                crossOrigin="anonymous"
+              />
+            </ReactCrop>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center justify-between p-5 border-t border-white/10 gap-3">
+          <Button
+            variant="outline"
+            onClick={onNewImage}
+            className="border-white/10 text-gray-300 hover:bg-white/5"
+          >
+            Anderes Bild
+          </Button>
+          <div className="flex gap-3">
+            <Button
+              variant="outline"
+              onClick={onCancel}
+              className="border-white/10 text-gray-300 hover:bg-white/5"
+            >
+              Abbrechen
+            </Button>
+            <Button
+              onClick={handleCrop}
+              disabled={processing || !crop}
+              className="bg-[#D4A574] hover:bg-[#E6B887] text-black font-semibold shadow-lg shadow-[#D4A574]/20"
+            >
+              {processing ? (
+                <span className="flex items-center gap-2">
+                  <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                  </svg>
+                  Wird zugeschnitten…
+                </span>
+              ) : (
+                <span className="flex items-center gap-2">
+                  <CropIcon className="w-4 h-4" />
+                  Zuschneiden & Übernehmen
+                </span>
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ProfileForm.tsx
+++ b/frontend/src/components/ProfileForm.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect } from "react";
+import React, { useMemo, useEffect, useState, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { User, MapPin, Music, Euro, FileText, ImageIcon, Images, Upload, X } from "lucide-react";
+import { ImageCropModal } from "./ImageCropModal";
 
 interface ProfileFormProps {
   profile: {
@@ -82,6 +83,8 @@ export function ProfileForm({
   fieldErrors
 }: ProfileFormProps) {
   const { t } = useTranslation();
+  const [cropFile, setCropFile] = useState<File | null>(null);
+  const profileInputRef = useRef<HTMLInputElement>(null);
 
   // Verwaltung der Blob-URLs für Galerie-Dateien
   const galleryBlobUrls = useMemo(() => {
@@ -97,9 +100,43 @@ export function ProfileForm({
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file) {
+    if (!file) return;
+
+    // Check if image is square — if not, open crop modal
+    const img = new Image();
+    const url = URL.createObjectURL(file);
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      const tolerance = 0.02; // 2% tolerance
+      const ratio = img.width / img.height;
+      if (Math.abs(ratio - 1) <= tolerance) {
+        // Already square (within tolerance) — accept directly
+        setProfile({ profileImageFile: file });
+      } else {
+        // Not square — open crop modal
+        setCropFile(file);
+      }
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      // Fall back to accepting the file directly
       setProfile({ profileImageFile: file });
-    }
+    };
+    img.src = url;
+
+    // Reset the input so the same file can be re-selected
+    e.target.value = '';
+  };
+
+  const handleCropComplete = (croppedFile: File) => {
+    setCropFile(null);
+    setProfile({ profileImageFile: croppedFile });
+  };
+
+  const handleCropNewImage = () => {
+    setCropFile(null);
+    // Trigger file picker again
+    profileInputRef.current?.click();
   };
 
   const handleGalleryUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -532,9 +569,10 @@ export function ProfileForm({
               locked && "opacity-50 cursor-not-allowed"
             )}>
               <Upload className="w-8 h-8 text-gray-400 mb-2" />
-              <span className="text-sm text-gray-400">Bild auswählen oder hierher ziehen</span>
-              <span className="text-xs text-gray-500 mt-1">PNG, JPG bis 5MB</span>
+              <span className="text-sm text-gray-400">Quadratisches Bild auswählen</span>
+              <span className="text-xs text-gray-500 mt-1">PNG, JPG – wird automatisch optimiert</span>
               <input
+                ref={profileInputRef}
                 type="file"
                 accept="image/*"
                 onChange={handleImageUpload}
@@ -542,6 +580,16 @@ export function ProfileForm({
                 className="hidden"
               />
             </label>
+
+            {/* Crop Modal */}
+            {cropFile && (
+              <ImageCropModal
+                file={cropFile}
+                onCropped={handleCropComplete}
+                onCancel={() => setCropFile(null)}
+                onNewImage={handleCropNewImage}
+              />
+            )}
           </CardContent>
         </Card>
 

--- a/frontend/src/lib/storage/blobUpload.ts
+++ b/frontend/src/lib/storage/blobUpload.ts
@@ -10,16 +10,26 @@
 
 export type UploadType = 'profile' | 'hero' | 'gallery' | 'invoice';
 
+/** Maximum file size in bytes (0.5 MB) */
+const MAX_FILE_SIZE = 500 * 1024;
+
 /**
- * Convert image to WebP format using canvas
+ * Convert image to WebP format using canvas.
+ * Iteratively reduces quality to stay under MAX_FILE_SIZE.
  */
-async function convertToWebP(file: File, maxWidth = 1200, maxHeight = 1200, quality = 0.85): Promise<Blob> {
+async function convertToWebP(
+  file: File,
+  maxWidth = 1200,
+  maxHeight = 1200,
+  quality = 0.85,
+  onProgress?: (step: string) => void
+): Promise<Blob> {
   return new Promise((resolve, reject) => {
     const img = new Image();
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
 
-    img.onload = () => {
+    img.onload = async () => {
       let { width, height } = img;
 
       if (width > maxWidth || height > maxHeight) {
@@ -31,25 +41,60 @@ async function convertToWebP(file: File, maxWidth = 1200, maxHeight = 1200, qual
       canvas.width = width;
       canvas.height = height;
 
-      if (ctx) {
-        ctx.drawImage(img, 0, 0, width, height);
-        canvas.toBlob(
-          (blob) => {
-            if (blob) {
-              resolve(blob);
-            } else {
-              reject(new Error('Failed to convert to WebP'));
-            }
-          },
-          'image/webp',
-          quality
-        );
-      } else {
+      if (!ctx) {
         reject(new Error('Canvas context not available'));
+        return;
+      }
+
+      ctx.drawImage(img, 0, 0, width, height);
+
+      // Try converting at the requested quality first
+      let currentQuality = quality;
+      let blob: Blob | null = null;
+
+      for (let attempt = 0; attempt < 6; attempt++) {
+        onProgress?.(
+          attempt === 0
+            ? 'Bild wird optimiert…'
+            : `Qualität wird angepasst… (${Math.round(currentQuality * 100)}%)`
+        );
+
+        blob = await new Promise<Blob | null>((res) => {
+          canvas.toBlob((b) => res(b), 'image/webp', currentQuality);
+        });
+
+        if (blob && blob.size <= MAX_FILE_SIZE) {
+          break;
+        }
+
+        // Reduce quality for next attempt
+        currentQuality = Math.max(0.3, currentQuality - 0.1);
+
+        // If quality is already low, also reduce dimensions
+        if (attempt >= 3 && blob && blob.size > MAX_FILE_SIZE) {
+          const scale = 0.8;
+          width = Math.round(width * scale);
+          height = Math.round(height * scale);
+          canvas.width = width;
+          canvas.height = height;
+          ctx.drawImage(img, 0, 0, width, height);
+        }
+      }
+
+      // Clean up the object URL
+      URL.revokeObjectURL(img.src);
+
+      if (blob) {
+        resolve(blob);
+      } else {
+        reject(new Error('Failed to convert to WebP'));
       }
     };
 
-    img.onerror = () => reject(new Error('Failed to load image'));
+    img.onerror = () => {
+      URL.revokeObjectURL(img.src);
+      reject(new Error('Failed to load image'));
+    };
     img.src = URL.createObjectURL(file);
   });
 }
@@ -108,24 +153,29 @@ export async function uploadProfileImage(
   setImageUrl: (url: string | null) => void,
   setDebug?: (message: string) => void,
   existingUrl: string | null = null,
-  _authToken?: string
+  _authToken?: string,
+  onProgress?: (step: string) => void
 ): Promise<string | null> {
   if (!file) {
     return existingUrl;
   }
 
   try {
+    onProgress?.('Bild wird optimiert…');
     setDebug?.('Converting profile image to WebP...');
-    const webpBlob = await convertToWebP(file, 800, 800, 0.9);
+    const webpBlob = await convertToWebP(file, 800, 800, 0.9, onProgress);
     const pathname = getStoragePath(artistId, 'profile');
 
-    setDebug?.(`Uploading profile image...`);
+    onProgress?.('Bild wird hochgeladen…');
+    setDebug?.(`Uploading profile image (${(webpBlob.size / 1024).toFixed(0)} KB)...`);
     const url = await uploadViaServerless(webpBlob, pathname);
 
     setImageUrl(url);
+    onProgress?.('Fertig!');
     setDebug?.(`Profile image uploaded: ${url}`);
     return url;
   } catch (error: any) {
+    onProgress?.('');
     setDebug?.(`Profile image upload failed: ${error.message}`);
     console.error('Profile upload error:', error);
     return existingUrl;
@@ -174,7 +224,8 @@ export async function uploadGalleryImages(
   existingUrls: string[],
   setGalleryUrls: (urls: string[]) => void,
   setDebug?: (message: string) => void,
-  _authToken?: string
+  _authToken?: string,
+  onProgress?: (step: string) => void
 ): Promise<string[]> {
   if (!files || files.length === 0) {
     return existingUrls;
@@ -184,7 +235,9 @@ export async function uploadGalleryImages(
     setDebug?.(`Uploading ${files.length} gallery images...`);
 
     const uploadPromises = files.map(async (file, index) => {
-      const webpBlob = await convertToWebP(file, 1200, 1200, 0.85);
+      onProgress?.(`Galeriebild ${index + 1}/${files.length} wird optimiert…`);
+      const webpBlob = await convertToWebP(file, 1200, 1200, 0.85, onProgress);
+      onProgress?.(`Galeriebild ${index + 1}/${files.length} wird hochgeladen…`);
       const pathname = `artists/${artistId}/gallery/${Date.now()}_${index}.webp`;
       return uploadViaServerless(webpBlob, pathname);
     });
@@ -192,9 +245,11 @@ export async function uploadGalleryImages(
     const newUrls = await Promise.all(uploadPromises);
     const allUrls = [...existingUrls, ...newUrls];
     setGalleryUrls(allUrls);
+    onProgress?.('Fertig!');
     setDebug?.(`Gallery upload complete: ${newUrls.length} images added`);
     return allUrls;
   } catch (error: any) {
+    onProgress?.('');
     setDebug?.(`Gallery upload failed: ${error.message}`);
     console.error('Gallery upload error:', error);
     return existingUrls;

--- a/frontend/src/pages/ProfileSetup.tsx
+++ b/frontend/src/pages/ProfileSetup.tsx
@@ -49,6 +49,7 @@ export default function Profile() {
   const [approvalStatus, setApprovalStatus] = useState<'approved' | 'pending' | 'rejected' | 'unsubmitted'>('unsubmitted');
   const [rejectionReason, setRejectionReason] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [uploadProgress, setUploadProgress] = useState<string>('');
 
   const unlockBtnRef = useRef<HTMLButtonElement | null>(null);
   const profileImageBlobUrlRef = useRef<string | null>(null);
@@ -215,7 +216,8 @@ export default function Profile() {
         setProfileImageUrl,
         setBackendDebug,
         profileImageUrl,
-        token || undefined
+        token || undefined,
+        setUploadProgress
       );
 
       // Upload gallery images via backend
@@ -225,8 +227,10 @@ export default function Profile() {
         galleryUrls,
         setGalleryUrls,
         setBackendDebug,
-        token || undefined
+        token || undefined,
+        setUploadProgress
       );
+      setUploadProgress('Profil wird gespeichert…');
 
       const nextStatus = approvalStatus === 'approved' ? 'approved' : 'pending';
 
@@ -308,6 +312,7 @@ export default function Profile() {
         setRejectionReason(saved.rejection_reason ?? null);
       }
 
+      setUploadProgress('');
       setSuccess(true);
       setFieldErrors({});
       window.scrollTo({ top: 0, behavior: "smooth" });
@@ -359,6 +364,7 @@ export default function Profile() {
         setBackendDebug(prev => `Sync error: ${err?.message || err}${prev ? "\n" + prev : ""}`);
       } finally {
       setLoading(false);
+      setUploadProgress('');
     }
   };
 
@@ -543,6 +549,25 @@ export default function Profile() {
           }}
           supportEmail="info@pepeshows.de"
         />
+
+        {/* Upload Progress Overlay */}
+        {loading && uploadProgress && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+            <div className="bg-[#1A1A1A] border border-white/10 rounded-2xl p-8 text-white max-w-sm w-full text-center shadow-2xl mx-4">
+              <div className="w-12 h-12 rounded-full bg-[#D4A574]/10 flex items-center justify-center mx-auto mb-4">
+                <svg className="w-6 h-6 text-[#D4A574] animate-spin" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
+              </div>
+              <h3 className="text-lg font-semibold mb-2">Wird verarbeitet</h3>
+              <p className="text-gray-400 text-sm">{uploadProgress}</p>
+              <div className="mt-4 h-1 bg-white/10 rounded-full overflow-hidden">
+                <div className="h-full bg-[#D4A574] rounded-full animate-pulse" style={{ width: '60%' }} />
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Profile Form - now uses Card components internally */}
         <div className="relative">


### PR DESCRIPTION
## Summary
- **Compression**: All uploaded images iteratively compressed to max 0.5MB via WebP quality reduction + dimension scaling
- **Square crop**: Profile image must be square — non-square images open a crop modal (react-image-crop)
- **Progress overlay**: Full-screen overlay during upload showing current step (optimizing/uploading/saving)

## Test plan
- [ ] Upload a large image (>2MB) → should be compressed to <0.5MB
- [ ] Upload a non-square profile image → crop modal appears
- [ ] Crop and accept → preview shows cropped square image
- [ ] Click "Anderes Bild" in crop modal → file picker reopens
- [ ] Upload square image → no crop modal, accepted directly
- [ ] Submit form → progress overlay shows optimization/upload status
- [ ] Gallery images also compressed to <0.5MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)